### PR TITLE
Generate correct cs-fixer path in .arclint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0",
+        "ext-json": "*",
         "ptlis/diff-parser": "^0.6.0"
     },
     "require-dev": {

--- a/composer/ArcConfigParser.php
+++ b/composer/ArcConfigParser.php
@@ -4,6 +4,7 @@ namespace Paysera\Composer;
 
 use Composer\Config;
 use Composer\Script\Event;
+use LinterConfiguration;
 
 class ArcConfigParser
 {
@@ -15,10 +16,10 @@ class ArcConfigParser
     public static function parseArcConfig(Event $event)
     {
         $phpCsBinary = $event->getComposer()->getConfig()
-                ->get('bin-dir', Config::RELATIVE_PATHS) . '/php-cs-fixer';
+                ->get('bin-dir', Config::RELATIVE_PATHS) . '/' . LinterConfiguration::BINARY_FILE;
 
         if (!file_exists($phpCsBinary)) {
-            $phpCsBinary = 'php-cs-fixer';
+            $phpCsBinary = LinterConfiguration::BINARY_FILE;
         }
 
         $parsedConfig = self::parseAndPrepareArcConfig($phpCsBinary);
@@ -53,7 +54,7 @@ class ArcConfigParser
         }
 
         if (!isset($arcConfig['lint.php_cs_fixer.fix_paths'])) {
-            $arcConfig['lint.php_cs_fixer.fix_paths'] = [\LinterConfiguration::SRC_DIRECTORY];
+            $arcConfig['lint.php_cs_fixer.fix_paths'] = [LinterConfiguration::SRC_DIRECTORY];
         }
 
         if (!isset($arcConfig['lint.php_cs_fixer.php_cs_binary'])) {
@@ -61,7 +62,7 @@ class ArcConfigParser
         }
 
         if (!isset($arcConfig['lint.php_cs_fixer.php_cs_file'])) {
-            $arcConfig['lint.php_cs_fixer.php_cs_file'] = \LinterConfiguration::PHP_CS_FILE;
+            $arcConfig['lint.php_cs_fixer.php_cs_file'] = LinterConfiguration::PHP_CS_FILE;
         }
 
         if (!isset($arcConfig['lint.php_cs_fixer.unified_diff_format'])) {

--- a/src/Lint/Engine/PhpCsFixerLintEngine.php
+++ b/src/Lint/Engine/PhpCsFixerLintEngine.php
@@ -18,7 +18,11 @@ final class PhpCsFixerLintEngine extends \ArcanistLintEngine
         $fixerPaths = $configManager
             ->getConfigFromAnySource('lint.php_cs_fixer.fix_paths', [LinterConfiguration::SRC_DIRECTORY]);
         $binaryPath = $configManager
-            ->getConfigFromAnySource('lint.php_cs_fixer.php_cs_binary', LinterConfiguration::BINARY_FILE);
+            ->getConfigFromAnySource(
+                'lint.php_cs_fixer.php_cs_binary',
+                LinterConfiguration::BIN_DIRECTORY . LinterConfiguration::BINARY_FILE
+            )
+        ;
 
         foreach ($paths as $key => $path) {
             if (!file_exists($this->getFilePathOnDisk($path))) {

--- a/src/Lint/Linter/LinterConfiguration.php
+++ b/src/Lint/Linter/LinterConfiguration.php
@@ -3,8 +3,9 @@
 class LinterConfiguration
 {
     const SRC_DIRECTORY = 'src/';
+    const BIN_DIRECTORY = 'bin/';
     const PHP_CS_FILE = '.php_cs';
-    const BINARY_FILE = 'bin/paysera-php-cs-fixer';
+    const BINARY_FILE = 'paysera-php-cs-fixer';
 
     /**
      * @var string
@@ -29,7 +30,7 @@ class LinterConfiguration
     public function __construct()
     {
         $this->paths = [];
-        $this->binaryFile = self::BINARY_FILE;
+        $this->binaryFile = self::BIN_DIRECTORY . self::BINARY_FILE;
         $this->phpCsFile = self::PHP_CS_FILE;
         $this->unifiedDiffFormat = true;
     }


### PR DESCRIPTION
Generate the correct cs-fixer path `bin/paysera-php-cs-fixer` initially,
when `.arclint` file is missing.